### PR TITLE
Fix gem version to support rubygems < 2.1

### DIFF
--- a/lib/metasploit/concern/version.rb
+++ b/lib/metasploit/concern/version.rb
@@ -25,7 +25,19 @@ module Metasploit
 
         version
       end
+
+      # The full gem version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
+      # {http://guides.rubygems.org/specification-reference/#version RubyGems versioning} format.
+      #
+      # @return [String] '{MAJOR}.{MINOR}.{PATCH}' on master.  '{MAJOR}.{MINOR}.{PATCH}.{PRERELEASE}' on any branch
+      #   other than master.
+      def self.gem
+        full.gsub('-', '.pre.')
+      end
     end
+
+    # @see Version.gem
+    GEM_VERSION = Version.gem
 
     # @see Version.full
     VERSION = Version.full

--- a/metasploit-concern.gemspec
+++ b/metasploit-concern.gemspec
@@ -6,7 +6,7 @@ require 'metasploit/concern/version'
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = 'metasploit-concern'
-  s.version     = Metasploit::Concern::VERSION
+  s.version     = Metasploit::Concern::GEM_VERSION
   s.authors     = ['Luke Imhoff']
   s.email       = ['luke_imhoff@rapid7.com']
   s.homepage    = 'https://github.com/rapid7/metasploit-concern'


### PR DESCRIPTION
https://jira.tor.rapid7.com/browse/MSP-10714
## Verification Steps
- [x] `gem update --system 1.8.23`
- [x] `bundle`
- [x] VERIFY: bundle completes successfully
- [x] VERIFY: `rake spec` completes successfully
## Land
- [x] Merge this PR
- [x] Remove `PRERELEASE` constant and comment from `lib/metasploit/concern/version.rb`.  Commit and push.
