### PR TITLE
Feature/msp 12084 fix metaspoloit concern deprecation warnings

### DIFF
--- a/lib/metasploit/concern/version.rb
+++ b/lib/metasploit/concern/version.rb
@@ -9,6 +9,8 @@ module Metasploit
       # The patch number, scoped to the {MINOR} version number.
       PATCH = 0
 
+      PRERELEASE = 'MSP-12084-fix-metaspoloit-concern-deprecation-warnings'
+
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
       #

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -6,8 +6,7 @@ Dummy::Application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
-  # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
+  config.eager_load = false
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -19,6 +19,8 @@ Dummy::Application.configure do
   # Generate digests for assets URLs
   config.assets.digest = true
 
+  config.eager_load = true
+
   # Defaults to nil and saved in location specified by config.assets.prefix
   # config.assets.manifest = YOUR_PATH
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -11,8 +11,7 @@ Dummy::Application.configure do
   config.serve_static_assets = true
   config.static_cache_control = "public, max-age=3600"
 
-  # Log error messages when you accidentally call methods on nil
-  config.whiny_nils = true
+  config.eager_load = true
 
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true


### PR DESCRIPTION
### Description
  
This PR eliminates the following warnings for Rails 4

* Fix whiny_nils warning
* Fix config.eager_load warning

### Verification Steps

Rails 3

* [x] `bundle install`
* [x] `rake spec`
* [x] verify no spec failures

Rails 4

* [x] switch to Rails 4 env
* [x] `bundle install`
* [x] `rake spec`
* [x] verify no whiny_nils deprecation warnings

  ```
  DEPRECATION WARNING: config.whiny_nils option is deprecated and no longer works.
  (called from block in <top (required)> at /Users/sgonzalez/rapid7/metasploit-concern/
  spec/dummy/config/environments/test.rb:15)
  ```

* [x] verify no config.eager_load warning

  ```
  config.eager_load is set to nil. Please update your config/environments/*.rb
  files accordingly:

    * development - set it to false
    * test - set it to false (unless you use a tool that preloads your test environment)
    * production - set it to true
  ```

### Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

### Version
* [ ] Edit `lib/metasploit-concern/version.rb`
* [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

### Gem build
* [ ] gem build *.gemspec
* [ ] VERIFY the gem has no '.pre' version suffix.

### RSpec
* [ ] `rake spec`
* [ ] VERIFY version examples pass without failures

### Commit & Push
* [ ] `git commit -a`
* [ ] `git push origin master`

## Release
### JRuby
* [ ] `rvm use jruby@metasploit-concern`
* [ ] `rm Gemfile.lock`
* [ ] `bundle install`
* [ ] `rake release`

### MRI Ruby
* [ ] `rvm use ruby-2.1.5@metasploit-concern`
* [ ] `rm Gemfile.lock`
* [ ] `bundle install`
* [ ] `rake release`
