### PR TITLE
Compatibility with Kernel.autoload or require loaded base classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,4 @@ env:
 language: ruby
 rvm:
   - '2.1'
-  - 'jruby-19mode'
-  - 'rbx-2'
 script: "bundle exec rake $RAKE_TASK"

--- a/app/models/metasploit/concern/loader.rb
+++ b/app/models/metasploit/concern/loader.rb
@@ -85,10 +85,6 @@ class Metasploit::Concern::Loader
         loader.each_pathname_constant(module_pathname) do |concern|
           include concern
         end
-
-        if defined?(Rails) && Rails.env.development?
-          unloadable
-        end
       end
     end
   end

--- a/app/models/metasploit/concern/loader.rb
+++ b/app/models/metasploit/concern/loader.rb
@@ -25,14 +25,19 @@ class Metasploit::Concern::Loader
 
   # Yields each constant under `parent_pathname`.
   #
+  # @param mechanism [:constantize, :require] `:require` if child pathname should be required so that the constant
+  #   cannot be unloaded by `ActiveSupport::Dependencies.clear`.
   # @param parent_pathname [Pathname]
   # @yield [constant]
   # @yieldparam constant [Module] constant declared under `parent_pathname`.
   # @yieldreturn [void]
   # @return [void]
-  def each_pathname_constant(parent_pathname)
+  def each_pathname_constant(mechanism:, parent_pathname:)
     parent_pathname.each_child do |child_pathname|
-      constant = constantize_pathname(child_pathname)
+      constant = constantize_pathname(
+          mechanism: mechanism,
+          pathname: child_pathname
+      )
 
       if constant
         yield constant
@@ -82,7 +87,13 @@ class Metasploit::Concern::Loader
       loader = self
 
       ActiveSupport.on_load(on_load_name) do
-        loader.each_pathname_constant(module_pathname) do |concern|
+        if ActiveSupport::Dependencies.autoloaded? self
+          mechanism = :constantize
+        else
+          mechanism = :require
+        end
+
+        loader.each_pathname_constant(mechanism: mechanism, parent_pathname: module_pathname) do |concern|
           include concern
         end
       end
@@ -93,15 +104,23 @@ class Metasploit::Concern::Loader
 
   # Converts `descendant_pathname`, which should be under {#root}, into a constant.
   #
-  # @param descendant_pathname [Pathname] a Pathname under {#root}.
+  # @param mechanism [:constantize, :require] `:require` if pathname should be required so that the constant cannot be
+  #   unloaded by `ActiveSupport::Dependencies.clear`.
+  # @param pathname [Pathname] a Pathname under {#root}.
   # @return [Object] if {#pathname_to_constant_name} returns a constant name
   # @return [nil] otherwise
-  def constantize_pathname(descendant_pathname)
-    constant_name = pathname_to_constant_name(descendant_pathname)
+  def constantize_pathname(mechanism:, pathname:)
+    constant_name = pathname_to_constant_name(pathname)
 
     constant = nil
 
     if constant_name
+      # require before calling constantize so that the constant isn't recorded as unloadable.
+      if mechanism == :require
+        require pathname
+      end
+
+      # constantize either way as the the constant_name still needs to be converted to Module
       constant = constant_name.constantize
     end
 

--- a/lib/metasploit/concern/version.rb
+++ b/lib/metasploit/concern/version.rb
@@ -6,8 +6,10 @@ module Metasploit
       MAJOR = 0
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 2
-      # The patch number, scoped to the {MINOR} version number.
-      PATCH = 1
+      # The patch number, scoped to the {MAJOR} and {MINOR} version numbers.
+      PATCH = 2
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'autoload-compatibility'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/app/models/metasploit/concern/loader_spec.rb
+++ b/spec/app/models/metasploit/concern/loader_spec.rb
@@ -336,10 +336,10 @@ describe Metasploit::Concern::Loader do
           ActiveSupport::Dependencies.explicitly_unloadable_constants.delete('Metasploit::Concern::ModuleWithConcerns')
         end
 
-        it 'does add module with concerns to unloadable constants' do
+        it 'does not add module with concerns to unloadable constants because it would causes required classes to no be reloaded' do
           register
 
-          expect(ActiveSupport::Dependencies.explicitly_unloadable_constants).to include('Metasploit::Concern::ModuleWithConcerns')
+          expect(ActiveSupport::Dependencies.explicitly_unloadable_constants).not_to include('Metasploit::Concern::ModuleWithConcerns')
         end
       end
 

--- a/spec/app/models/metasploit/concern/loader_spec.rb
+++ b/spec/app/models/metasploit/concern/loader_spec.rb
@@ -22,22 +22,12 @@ describe Metasploit::Concern::Loader do
       root.join('metasploit', 'concern', 'module_with_concerns')
     end
 
-    let(:metasploit_concern_module_with_concerns) do
-      Module.new do
-        ActiveSupport.run_load_hooks(:metasploit_concern_module_with_concerns, self)
-      end
-    end
-
     #
     # Callbacks
     #
 
     before(:all) do
       remove_load_hooks
-    end
-
-    before(:each) do
-      stub_const('Metasploit::Concern::ModuleWithConcerns', metasploit_concern_module_with_concerns)
     end
 
     after(:each) do
@@ -140,6 +130,16 @@ describe Metasploit::Concern::Loader do
   end
 
   around(:each) do |example|
+    mechanism_before = ActiveSupport::Dependencies.mechanism
+
+    begin
+      example.run
+    ensure
+      ActiveSupport::Dependencies.mechanism = mechanism_before
+    end
+  end
+
+  around(:each) do |example|
     autoload_paths_before = ActiveSupport::Dependencies.autoload_paths.dup
 
     begin
@@ -150,9 +150,7 @@ describe Metasploit::Concern::Loader do
   end
 
   before(:each) do
-    # add to load path so that constantize works
-    $LOAD_PATH.unshift(load_path)
-    ActiveSupport::Dependencies.autoload_paths << load_path
+    ActiveSupport::Dependencies.mechanism = :load
   end
 
   after(:each) do
@@ -166,6 +164,12 @@ describe Metasploit::Concern::Loader do
   context '#constantize_pathname' do
     subject(:constantize_pathname) do
       loader.send(:constantize_pathname, descendant_pathname)
+    end
+
+    before(:each) do
+      # add to load path so that constantize works
+      $LOAD_PATH.unshift(load_path)
+      ActiveSupport::Dependencies.autoload_paths << load_path
     end
 
     context 'with constant name' do
@@ -200,8 +204,22 @@ describe Metasploit::Concern::Loader do
   context '#each_pathname_constant' do
     include_context 'Metasploit::Concern::ModuleWithConcerns::ConcernForModule'
 
+    #
+    # Methods
+    #
+
     def each_pathname_constant(&block)
       loader.each_pathname_constant(module_pathname, &block)
+    end
+
+    #
+    # Callbacks
+    #
+
+    before(:each) do
+      # add to load path so that constantize works
+      $LOAD_PATH.unshift(load_path)
+      ActiveSupport::Dependencies.autoload_paths << load_path
     end
 
     it 'yields concerns' do
@@ -305,12 +323,107 @@ describe Metasploit::Concern::Loader do
       loader.register
     end
 
-    it 'includes concerns' do
-      expect {
-        register
-      }.to change {
-        Metasploit::Concern::ModuleWithConcerns.ancestors.map(&:name).include? concern_name
-      }.to(true)
+    context 'with base class ActiveSupport::Dependencies.autoloaded?' do
+      before(:each) do
+        module_pathname.parent.mkpath
+
+        open("#{module_pathname}.rb", 'w') do |f|
+          f.puts "class Metasploit::Concern::ModuleWithConcerns"
+          f.puts "  ActiveSupport.run_load_hooks(:metasploit_concern_module_with_concerns, self)"
+          f.puts "end"
+        end
+      end
+
+      before(:each) do
+        $LOAD_PATH.unshift(load_path)
+        ActiveSupport::Dependencies.autoload_paths << load_path
+      end
+
+      after(:each) do
+        Metasploit::Concern.send(:remove_const, :ModuleWithConcerns)
+      end
+
+      context 'false' do
+        #
+        # Callbacks
+        #
+
+        before(:each) do
+          Metasploit::Concern.autoload :ModuleWithConcerns, 'metasploit/concern/module_with_concerns.rb'
+        end
+
+        it 'has base class loaded' do
+          expect {
+            Metasploit::Concern::ModuleWithConcerns
+          }.not_to raise_error
+
+          expect(Metasploit::Concern::ModuleWithConcerns).to be_a Class
+        end
+
+        it 'includes concerns' do
+          expect {
+            register
+          }.to change {
+                 Metasploit::Concern::ModuleWithConcerns.ancestors.map(&:name).include? concern_name
+               }.to(true)
+        end
+
+        it 'does not end up with two copies of concern when reloaded' do
+          register
+
+          Metasploit::Concern::ModuleWithConcerns
+          expect(Metasploit::Concern::ModuleWithConcerns.ancestors.map(&:name).count(concern_name)).to eq(1)
+
+          expect {
+            ActiveSupport::Dependencies.clear
+          }.to change {
+                 Metasploit::Concern::ModuleWithConcerns.constants.include? concern_relative_name.to_sym
+               }.to(false)
+
+          Metasploit::Concern::ModuleWithConcerns.send(
+              :include,
+              Metasploit::Concern::ModuleWithConcerns::ConcernForModule
+          )
+
+          expect(Metasploit::Concern::ModuleWithConcerns.ancestors.map(&:name).count(concern_name)).to eq(1)
+        end
+      end
+
+      context 'true' do
+        it 'has base class loaded' do
+          expect {
+            Metasploit::Concern::ModuleWithConcerns
+          }.not_to raise_error
+
+          expect(Metasploit::Concern::ModuleWithConcerns).to be_a Class
+        end
+
+        it 'includes concerns' do
+          expect {
+            register
+          }.to change {
+                 Metasploit::Concern::ModuleWithConcerns.ancestors.map(&:name).include? concern_name
+               }.to(true)
+        end
+
+        it 'does not end up with two copies of concern when reloaded and included' do
+          register
+
+          Metasploit::Concern::ModuleWithConcerns
+          expect(Metasploit::Concern::ModuleWithConcerns.ancestors.map(&:name).count(concern_name)).to eq(1)
+
+          ActiveSupport::Dependencies.clear
+          expect(Metasploit::Concern.constants).not_to include(:ModuleWithConcerns),
+                                                       'Expected Metasploit::Concern::ModuleWithConcerns to be unloaded by ActiveSupport::Dependencies.clear'
+
+          Metasploit::Concern::ModuleWithConcerns.send(
+              :include,
+              Metasploit::Concern::ModuleWithConcerns::ConcernForModule
+          )
+
+          expect(Metasploit::Concern::ModuleWithConcerns.ancestors.map(&:name).count(concern_name)).to eq(1)
+        end
+      end
     end
 
     # rspec run with Rails loaded for Rails::Engine, so no need to stub Rails

--- a/spec/app/models/metasploit/concern/loader_spec.rb
+++ b/spec/app/models/metasploit/concern/loader_spec.rb
@@ -163,7 +163,7 @@ describe Metasploit::Concern::Loader do
 
   context '#constantize_pathname' do
     subject(:constantize_pathname) do
-      loader.send(:constantize_pathname, descendant_pathname)
+      loader.send(:constantize_pathname, mechanism: :constantize, pathname: descendant_pathname)
     end
 
     before(:each) do
@@ -209,7 +209,7 @@ describe Metasploit::Concern::Loader do
     #
 
     def each_pathname_constant(&block)
-      loader.each_pathname_constant(module_pathname, &block)
+      loader.each_pathname_constant(mechanism: :constantize, parent_pathname: module_pathname, &block)
     end
 
     #
@@ -376,9 +376,9 @@ describe Metasploit::Concern::Loader do
 
           expect {
             ActiveSupport::Dependencies.clear
-          }.to change {
+          }.not_to change {
                  Metasploit::Concern::ModuleWithConcerns.constants.include? concern_relative_name.to_sym
-               }.to(false)
+               }
 
           Metasploit::Concern::ModuleWithConcerns.send(
               :include,


### PR DESCRIPTION
MSP-12527

1. Do not mark the base class as `unloadable` as classes loaded with `Kernel.autoload` or `require` does not be unloaded and base class loaded with `ActiveSupport::Dependencies.autoload_paths` will already be unloadable.
2. If a base class is not loaded with `ActiveSupport::Dependencies.autoload_paths`, then `require` the concerns to prevent the concerns from being unloaded and reloaded.  Allowing concerns to reload would all the concern to be re-included as Ruby check if a Module is included based on object_id and not Module#name.

# Verification Steps

## metasploit-concern
- [x] `bundle install`

### `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

### `rake features`
- [x] `rake features`
- [x] VERIFY no failures

## pro
VERIFY MSP-12509 is fixed.

- [x] `cd rapid7/pro`
- [x] `git checkout bug/MSP-12527/autoload-compatibility`
- [x] `foreman start`
- [x] `open localhost:5000`
- [x] VERIFY the app doesn't give stacktrace with `NoMethodError - undefined method `find_by_active' for Mdm::Profile:Module`.

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/concern/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on master
## `VERSION`

### Compatible changes

- [`PATCH`](lib/metasploit/concern/version.rb) has been increment already.

## MRI Ruby
- [ ] `rvm use ruby-2.1@metasploit-concern`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`