### PR TITLE
'app/concerns' cannot be eager_load: true nor autoload: false

### DIFF
--- a/lib/metasploit/concern.rb
+++ b/lib/metasploit/concern.rb
@@ -77,6 +77,11 @@ module Metasploit
   #     end
   #   end
   module Concern
+    extend ActiveSupport::Autoload
+
+    autoload :Error
+    autoload :EagerLoadError
+
     # @note If `Rails` is loaded and {Metasploit::Concern::Engine} is defined, just use
     #   `Metasploit::Concern::Engine.root`.
     #

--- a/lib/metasploit/concern.rb
+++ b/lib/metasploit/concern.rb
@@ -4,6 +4,8 @@
 
 # `String#underscore``
 require 'active_support/core_ext/string/inflections'
+# `ActiveSupport::Autoload`
+require 'active_support/dependencies/autoload'
 # `ActiveSupport.run_load_hooks`
 require 'active_support/lazy_load_hooks'
 

--- a/lib/metasploit/concern/engine.rb
+++ b/lib/metasploit/concern/engine.rb
@@ -39,16 +39,12 @@ module Metasploit
             end
 
             concerns_directories = concerns_path.existent_directories
-          else
-            # app/concerns is not set, so just derive it from root.  Cannot
-            # derive from app because it will glob app/models too
-            concerns_directories = [engine.root.join('app', 'concerns').to_path]
-          end
 
-          concerns_directories.each do |concerns_directory|
-            concerns_pathname = Pathname.new(concerns_directory)
-            loader = Metasploit::Concern::Loader.new(root: concerns_pathname)
-            loader.register
+            concerns_directories.each do |concerns_directory|
+              concerns_pathname = Pathname.new(concerns_directory)
+              loader = Metasploit::Concern::Loader.new(root: concerns_pathname)
+              loader.register
+            end
           end
         end
       end

--- a/lib/metasploit/concern/engine.rb
+++ b/lib/metasploit/concern/engine.rb
@@ -34,6 +34,10 @@ module Metasploit
               raise Metasploit::Concern::Error::EagerLoad, engine
             end
 
+            unless concerns_path.autoload?
+              raise Metasploit::Concern::Error::SkipAutoload, engine
+            end
+
             concerns_directories = concerns_path.existent_directories
           else
             # app/concerns is not set, so just derive it from root.  Cannot

--- a/lib/metasploit/concern/engine.rb
+++ b/lib/metasploit/concern/engine.rb
@@ -30,6 +30,10 @@ module Metasploit
           concerns_path = engine.paths['app/concerns']
 
           if concerns_path
+            if concerns_path.eager_load?
+              raise Metasploit::Concern::Error::EagerLoad, engine
+            end
+
             concerns_directories = concerns_path.existent_directories
           else
             # app/concerns is not set, so just derive it from root.  Cannot

--- a/lib/metasploit/concern/error.rb
+++ b/lib/metasploit/concern/error.rb
@@ -4,4 +4,5 @@ module Metasploit::Concern::Error
 
   autoload :Base
   autoload :EagerLoad
+  autoload :SkipAutoload
 end

--- a/lib/metasploit/concern/error.rb
+++ b/lib/metasploit/concern/error.rb
@@ -1,0 +1,7 @@
+# Namespace for errors raised by {Metasploit::Concern}.
+module Metasploit::Concern::Error
+  extend ActiveSupport::Autoload
+
+  autoload :Base
+  autoload :EagerLoad
+end

--- a/lib/metasploit/concern/error/base.rb
+++ b/lib/metasploit/concern/error/base.rb
@@ -1,0 +1,4 @@
+# Base of exception hierarchy raise by {Metasploit::Concern}
+class Metasploit::Concern::Error::Base < StandardError
+
+end

--- a/lib/metasploit/concern/error/eager_load.rb
+++ b/lib/metasploit/concern/error/eager_load.rb
@@ -1,0 +1,17 @@
+# Exception raised when a `Rails::Engine` has left its `'app/concerns'` path as `eager_load: true`
+class Metasploit::Concern::Error::EagerLoad < Metasploit::Concern::Error::Base
+  # @param engine [Rails::Engine] `Rails::Engine` where `engine.paths['app/concerns'].eager_load?` is `true`.
+  def initialize(engine)
+    @engine = engine
+
+    super(
+        "#{engine}'s `app/concerns` is marked as `eager_load: true`.  This will cause circular dependency " \
+        "errors when the concerns are loaded.  Declare `app/concerns` to stop it from inheriting `eager_load: true` " \
+        "from `app`: \n" \
+        "\n" \
+        "  class #{engine} < Rails::Engine\n" \
+        "    config.paths.add 'app/concerns', autoload: true\n" \
+        "  end\n"
+    )
+  end
+end

--- a/lib/metasploit/concern/error/skip_autoload.rb
+++ b/lib/metasploit/concern/error/skip_autoload.rb
@@ -1,0 +1,15 @@
+# Exception raised when a `Rails::Engine` has left its `'app/concerns'` path as `autoload_load: false`
+class Metasploit::Concern::Error::SkipAutoload < Metasploit::Concern::Error::Base
+  # @param engine [Rails::Engine] `Rails::Engine` where `engine.paths['app/concerns'].autoload?` is `false`.
+  def initialize(engine)
+    @engine = engine
+
+    super(
+        "#{engine}'s `app/concerns` is marked as `autoload: false`.  Declare `app/concerns` as autoloading:\n" \
+        "\n" \
+        "  class #{engine} < Rails::Engine\n" \
+        "    config.paths.add 'app/concerns', autoload: true\n" \
+        "  end\n"
+    )
+  end
+end

--- a/lib/metasploit/concern/version.rb
+++ b/lib/metasploit/concern/version.rb
@@ -5,9 +5,11 @@ module Metasploit
       # The major version number.
       MAJOR = 0
       # The minor version number, scoped to the {MAJOR} version number.
-      MINOR = 3
+      MINOR = 4
       # The patch number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 1
+      PATCH = 0
+      # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'app-concerns-eager-load'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/lib/metasploit/concern/engine_spec.rb
+++ b/spec/lib/metasploit/concern/engine_spec.rb
@@ -11,6 +11,84 @@ describe Metasploit::Concern::Engine do
         expect(instance).to be_a Dummy::ModelWithConcern::ConcernForModel
         expect(instance).to respond_to :instance_method_from_concern
       end
+
+      context 'with engine' do
+        context "with 'app/concerns'" do
+          #
+          # lets
+          #
+
+          let(:application) {
+            Class.new(Rails::Engine)
+          }
+
+          let(:context) {
+            Object.new
+          }
+
+          let(:load_concerns) {
+            described_class.initializers.find { |initializer|
+              initializer.name == "metasploit_concern.load_concerns"
+            }.bind(context)
+          }
+
+          #
+          # Callbacks
+          #
+
+          before(:each) do
+            stub_const('EngineUnderTest', engine)
+
+            railties = double(engines: [engine])
+
+            allow(application).to receive(:railties).and_return(railties)
+            allow(Rails).to receive(:application).and_return(application)
+          end
+
+          context 'with `eager_load: true`' do
+            #
+            # lets
+            #
+
+            let(:engine) {
+              Class.new(Rails::Engine) do
+                config.paths.add 'app/concerns', eager_load: true
+              end
+            }
+
+            it 'raises Metasploit::Concern::Error::EagerLoad' do
+              expect {
+                load_concerns.run
+              }.to raise_error Metasploit::Concern::Error::EagerLoad,
+                               "#{engine}'s `app/concerns` is marked as `eager_load: true`.  This will cause " \
+                               "circular dependency errors when the concerns are loaded.  Declare `app/concerns` to " \
+                               "stop it from inheriting `eager_load: true` from `app`: \n" \
+                               "\n" \
+                               "  class #{engine} < Rails::Engine\n" \
+                               "    config.paths.add 'app/concerns', autoload: true\n" \
+                               "  end\n"
+            end
+          end
+
+          context 'without `eager_load: true`' do
+            #
+            # lets
+            #
+
+            let(:engine) {
+              Class.new(Rails::Engine) do
+                config.paths.add 'app/concerns'
+              end
+            }
+
+            it 'does not raise Metasploit::Concern::Error::EagerLoad' do
+              expect {
+                load_concerns.run
+              }.not_to raise_error
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/metasploit/concern/engine_spec.rb
+++ b/spec/lib/metasploit/concern/engine_spec.rb
@@ -46,10 +46,6 @@ describe Metasploit::Concern::Engine do
           end
 
           context 'with `eager_load: true`' do
-            #
-            # lets
-            #
-
             let(:engine) {
               Class.new(Rails::Engine) do
                 config.paths.add 'app/concerns', eager_load: true
@@ -71,20 +67,38 @@ describe Metasploit::Concern::Engine do
           end
 
           context 'without `eager_load: true`' do
-            #
-            # lets
-            #
+            context 'with `autoload: true`' do
+              let(:engine) {
+                Class.new(Rails::Engine) do
+                  config.paths.add 'app/concerns', autoload: true
+                end
+              }
 
-            let(:engine) {
-              Class.new(Rails::Engine) do
-                config.paths.add 'app/concerns'
+              it 'does not raise error' do
+                expect {
+                  load_concerns.run
+                }.not_to raise_error
               end
-            }
+            end
 
-            it 'does not raise Metasploit::Concern::Error::EagerLoad' do
-              expect {
-                load_concerns.run
-              }.not_to raise_error
+            context 'without `autoload: true`' do
+              let(:engine) {
+                Class.new(Rails::Engine) do
+                  config.paths.add 'app/concerns'
+                end
+              }
+
+              it 'raises Metasploit::Concern::Error::SkipAutoLoad' do
+                expect {
+                  load_concerns.run
+                }.to raise_error Metasploit::Concern::Error::SkipAutoload,
+                                 "#{engine}'s `app/concerns` is marked as `autoload: false`.  Declare `app/concerns` " \
+                                 "as autoloading:\n" \
+                                 "\n" \
+                                 "  class #{engine} < Rails::Engine\n" \
+                                 "    config.paths.add 'app/concerns', autoload: true\n" \
+                                 "  end\n"
+              end
             end
           end
         end


### PR DESCRIPTION
MSP-12550

1. Raise an error if 'app/concerns' is `eager_load: true` as it causes circular dependency error when the base class is `Kernel.autoload`ed.
2. Raise an error if 'app/concerns' is `autoload: false` as the concerns must use `ActiveSupport::Dependencies.autoload` in cases where the base class is also using `ActiveSupport::Dependenices.autoload`.
3. Do not derive 'app/concerns' from `root` as by default 'app/concerns' will inherit `eager_load: true` from the 'app' path.

# Verification Steps
- [x] `rm Gemfile.lock`
- [x] `bundle install`

## Tests
- [x] `rake features spec`
- [x] VERIFY no errors
- [x] `open coverage/index.html`
- [x] VERIFY `raises` in `metasploit/concern/engine.rb` are covered.

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/concern/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on master

## `VERSION`

### Incompatible changes

1. [`MINOR`](lib/metasploit/concern/version.rb) has been incremented
2. [`PATCH`](lib/metasploit/concern/version.rb) has been reset to `0`.

## MRI Ruby
- [ ] `rvm use ruby-2.1@metasploit-concern`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`