### PR TITLE
Test app/concerns is not derived

### DIFF
--- a/lib/metasploit/concern/version.rb
+++ b/lib/metasploit/concern/version.rb
@@ -7,9 +7,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 4
       # The patch number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 0
+      PATCH = 1
       # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
-      # PRERELEASE =
+      PRERELEASE = 'root-app-concerns'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.


### PR DESCRIPTION
MSP-12559

Test that `app/concerns` is NOT derived from `<root>/app/concerns`

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/concern/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

No release is necessary as this is a test only fix.