### PR TITLE
Fix circular dependency in ActiveSupport::Dependencies base class loading tests for Rails 4.0

### DIFF
--- a/lib/metasploit/concern/version.rb
+++ b/lib/metasploit/concern/version.rb
@@ -7,7 +7,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 5
       # The patch number, scoped to the {MAJOR} and {MINOR} version numbers.
-      PATCH = 0
+      PATCH = 1
+      # The prerelease version number, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'circular-dependency-master'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/app/models/metasploit/concern/loader_spec.rb
+++ b/spec/app/models/metasploit/concern/loader_spec.rb
@@ -339,10 +339,6 @@ describe Metasploit::Concern::Loader do
         ActiveSupport::Dependencies.autoload_paths << load_path
       end
 
-      after(:each) do
-        Metasploit::Concern.send(:remove_const, :ModuleWithConcerns)
-      end
-
       context 'false' do
         #
         # Callbacks
@@ -350,6 +346,10 @@ describe Metasploit::Concern::Loader do
 
         before(:each) do
           Metasploit::Concern.autoload :ModuleWithConcerns, 'metasploit/concern/module_with_concerns.rb'
+        end
+
+        after(:each) do
+          Metasploit::Concern.send(:remove_const, :ModuleWithConcerns)
         end
 
         it 'has base class loaded' do
@@ -390,6 +390,10 @@ describe Metasploit::Concern::Loader do
       end
 
       context 'true' do
+        after(:each) do
+          ActiveSupport::Dependencies.clear
+        end
+
         it 'has base class loaded' do
           expect {
             Metasploit::Concern::ModuleWithConcerns


### PR DESCRIPTION
MSP-12591

**NOTE: This PR is against master even though the bug only shows on staging/rails-4.0 because it is still incorrect behavior for the tests not to clean up on master**

# Verification Steps

## On master
- [x] `rvm use ruby-2.1@metasploit-concern`
- [x] `rm Gemfile.lock`
- [x] `bundle install`

### `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

## On staging/rails-4.0
- [x] `git checkout staging/rails-4.0`
- [x] `rvm use ruby-2.1@metasploit-concern-rails-4.0`
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `git diff master..bug/MSP-12591/circular-dependency-master -- spec/app/models/metasploit/concern/loader_spec.rb | git apply`

### `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/concern/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`

# Release

Complete these steps on master

## `VERSION`

### Compatible changes

- Incremented [`PATCH`](lib/metasploit/concern/version.rb).

## MRI Ruby
- [ ] `rvm use ruby-2.1@metasploit-concern`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

# Post-merge steps
- [ ] Merge to staging/rails-4.0