### PR TITLE
convert specs with transpec

### DIFF
--- a/lib/metasploit/concern/version.rb
+++ b/lib/metasploit/concern/version.rb
@@ -7,7 +7,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 0
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 0
+      PATCH = 1
+
+      PRERELEASE = 'transpec-conversion'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/app/models/metasploit/concern/loader_spec.rb
+++ b/spec/app/models/metasploit/concern/loader_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Concern::Loader do
+RSpec.describe Metasploit::Concern::Loader do
   shared_context 'Metasploit::Concern::ModuleWithConcerns' do
     #
     # Methods
@@ -26,11 +26,11 @@ describe Metasploit::Concern::Loader do
     # Callbacks
     #
 
-    before(:all) do
+    before(:context) do
       remove_load_hooks
     end
 
-    after(:each) do
+    after(:example) do
       remove_load_hooks
     end
   end
@@ -58,7 +58,7 @@ describe Metasploit::Concern::Loader do
     # Callbacks
     #
 
-    before(:each) do
+    before(:example) do
       concern_pathname.parent.mkpath
 
       concern_pathname.open('w') do |f|
@@ -67,7 +67,7 @@ describe Metasploit::Concern::Loader do
       end
     end
 
-    after(:each) do
+    after(:example) do
       ActiveSupport::Dependencies.clear
     end
   end
@@ -105,11 +105,11 @@ describe Metasploit::Concern::Loader do
   #
 
   # clean up interrupted run
-  before(:all) do
+  before(:context) do
     remove_root
   end
 
-  around(:each) do |example|
+  around(:example) do |example|
     loaded_features_before = $LOADED_FEATURES.dup
 
     begin
@@ -119,7 +119,7 @@ describe Metasploit::Concern::Loader do
     end
   end
 
-  around(:each) do |example|
+  around(:example) do |example|
     load_path_before = $LOAD_PATH.dup
 
     begin
@@ -129,7 +129,7 @@ describe Metasploit::Concern::Loader do
     end
   end
 
-  around(:each) do |example|
+  around(:example) do |example|
     mechanism_before = ActiveSupport::Dependencies.mechanism
 
     begin
@@ -139,7 +139,7 @@ describe Metasploit::Concern::Loader do
     end
   end
 
-  around(:each) do |example|
+  around(:example) do |example|
     autoload_paths_before = ActiveSupport::Dependencies.autoload_paths.dup
 
     begin
@@ -149,16 +149,16 @@ describe Metasploit::Concern::Loader do
     end
   end
 
-  before(:each) do
+  before(:example) do
     ActiveSupport::Dependencies.mechanism = :load
   end
 
-  after(:each) do
+  after(:example) do
     remove_root
   end
 
   context 'validations' do
-    it { should validate_presence_of :root }
+    it { is_expected.to validate_presence_of :root }
   end
 
   context '#constantize_pathname' do
@@ -166,7 +166,7 @@ describe Metasploit::Concern::Loader do
       loader.send(:constantize_pathname, mechanism: :constantize, pathname: descendant_pathname)
     end
 
-    before(:each) do
+    before(:example) do
       # add to load path so that constantize works
       $LOAD_PATH.unshift(load_path)
       ActiveSupport::Dependencies.autoload_paths << load_path
@@ -197,7 +197,7 @@ describe Metasploit::Concern::Loader do
         module_pathname.join("concern_for_module#{invalid_extension}")
       end
 
-      it { should be_nil }
+      it { is_expected.to be_nil }
     end
   end
 
@@ -216,7 +216,7 @@ describe Metasploit::Concern::Loader do
     # Callbacks
     #
 
-    before(:each) do
+    before(:example) do
       # add to load path so that constantize works
       $LOAD_PATH.unshift(load_path)
       ActiveSupport::Dependencies.autoload_paths << load_path
@@ -238,7 +238,7 @@ describe Metasploit::Concern::Loader do
       loader.glob
     end
 
-    it { should be_a Pathname }
+    it { is_expected.to be_a Pathname }
 
     it 'is all .rb files under #root' do
       expect(glob).to eq(root.join('**', '*.rb'))
@@ -260,7 +260,7 @@ describe Metasploit::Concern::Loader do
       root.join('metasploit', 'concern', 'module_without_concerns')
     end
 
-    before(:each) do
+    before(:example) do
       non_module_pathname.mkpath
 
       expected_module_pathnames.each do |expected_module_pathname|
@@ -273,7 +273,7 @@ describe Metasploit::Concern::Loader do
       end
     end
 
-    it { should be_a Set }
+    it { is_expected.to be_a Set }
 
     it 'includes directories under #root that have .rb files' do
       expected_module_pathnames.each do |expected_module_pathname|
@@ -311,7 +311,7 @@ describe Metasploit::Concern::Loader do
           '.rb.bak'
         end
 
-        it { should be_nil }
+        it { is_expected.to be_nil }
       end
     end
   end
@@ -324,7 +324,7 @@ describe Metasploit::Concern::Loader do
     end
 
     context 'with base class ActiveSupport::Dependencies.autoloaded?' do
-      before(:each) do
+      before(:example) do
         module_pathname.parent.mkpath
 
         open("#{module_pathname}.rb", 'w') do |f|
@@ -334,7 +334,7 @@ describe Metasploit::Concern::Loader do
         end
       end
 
-      before(:each) do
+      before(:example) do
         $LOAD_PATH.unshift(load_path)
         ActiveSupport::Dependencies.autoload_paths << load_path
       end
@@ -344,11 +344,11 @@ describe Metasploit::Concern::Loader do
         # Callbacks
         #
 
-        before(:each) do
+        before(:example) do
           Metasploit::Concern.autoload :ModuleWithConcerns, 'metasploit/concern/module_with_concerns.rb'
         end
 
-        after(:each) do
+        after(:example) do
           Metasploit::Concern.send(:remove_const, :ModuleWithConcerns)
         end
 
@@ -390,7 +390,7 @@ describe Metasploit::Concern::Loader do
       end
 
       context 'true' do
-        after(:each) do
+        after(:example) do
           ActiveSupport::Dependencies.clear
         end
 
@@ -445,11 +445,11 @@ describe Metasploit::Concern::Loader do
         # Callbacks
         #
 
-        before(:each) do
+        before(:example) do
           allow(Rails).to receive(:env).and_return(env)
         end
 
-        after(:each) do
+        after(:example) do
           ActiveSupport::Dependencies.explicitly_unloadable_constants.delete('Metasploit::Concern::ModuleWithConcerns')
         end
 

--- a/spec/lib/metasploit/concern/engine_spec.rb
+++ b/spec/lib/metasploit/concern/engine_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Concern::Engine do
+RSpec.describe Metasploit::Concern::Engine do
   context 'initializers' do
     context 'metasploit_concern.load_concerns' do
       it 'includes concerns' do
@@ -28,14 +28,14 @@ describe Metasploit::Concern::Engine do
         let(:load_concerns) {
           described_class.initializers.find { |initializer|
             initializer.name == "metasploit_concern.load_concerns"
-          }.bind(context)
+          }.bind(RSpec.context)
         }
 
         #
         # Callbacks
         #
 
-        before(:each) do
+        before(:example) do
           stub_const('ApplicationUnderTest', application)
           stub_const('EngineUnderTest', engine)
 
@@ -90,11 +90,11 @@ describe Metasploit::Concern::Engine do
               # Callbacks
               #
 
-              before(:each) do
+              before(:example) do
                 root.join('app', 'concerns').mkpath
               end
 
-              after(:each) do
+              after(:example) do
                 root.rmtree
               end
 
@@ -160,11 +160,11 @@ describe Metasploit::Concern::Engine do
           # Callbacks
           #
 
-          before(:each) do
+          before(:example) do
             root.join('app', 'concerns').mkpath
           end
 
-          after(:each) do
+          after(:example) do
             root.rmtree
           end
 

--- a/spec/lib/metasploit/concern/version_spec.rb
+++ b/spec/lib/metasploit/concern/version_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe Metasploit::Concern::Version do
+RSpec.describe Metasploit::Concern::Version do
   context 'CONSTANTS' do
     context 'MAJOR' do
       subject(:major) do
         described_class::MAJOR
       end
 
-      it { should be_a Integer }
+      it { is_expected.to be_a Integer }
     end
 
     context 'MINOR' do
@@ -15,7 +15,7 @@ describe Metasploit::Concern::Version do
         described_class::MINOR
       end
 
-      it { should be_a Integer }
+      it { is_expected.to be_a Integer }
     end
 
     context 'PATCH' do
@@ -23,7 +23,7 @@ describe Metasploit::Concern::Version do
         described_class::PATCH
       end
 
-      it { should be_a Integer }
+      it { is_expected.to be_a Integer }
     end
 
     pull_request = ENV['TRAVIS_PULL_REQUEST']
@@ -106,7 +106,7 @@ describe Metasploit::Concern::Version do
       3
     end
 
-    before(:each) do
+    before(:example) do
       stub_const("#{described_class}::MAJOR", major)
       stub_const("#{described_class}::MINOR", minor)
       stub_const("#{described_class}::PATCH", patch)
@@ -117,7 +117,7 @@ describe Metasploit::Concern::Version do
         'prerelease'
       end
 
-      before(:each) do
+      before(:example) do
         stub_const("#{described_class}::PRERELEASE", prerelease)
       end
 
@@ -127,7 +127,7 @@ describe Metasploit::Concern::Version do
     end
 
     context 'without PRERELEASE' do
-      before(:each) do
+      before(:example) do
         hide_const("#{described_class}::PRERELEASE")
       end
 

--- a/spec/lib/metasploit/concern_spec.rb
+++ b/spec/lib/metasploit/concern_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Metasploit::Concern do
+RSpec.describe Metasploit::Concern do
   context 'CONSTANTS' do
     context 'VERSION' do
       subject(:version) do

--- a/spec/metasploit/concern/loader/support_spec.rb
+++ b/spec/metasploit/concern/loader/support_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Metasploit::Concern.run shared example' do
+RSpec.describe 'Metasploit::Concern.run shared example' do
   subject(:instance) {
     described_class.new
   }
@@ -21,7 +21,7 @@ describe 'Metasploit::Concern.run shared example' do
   # Callbacks
   #
 
-  before(:each) do
+  before(:example) do
     stub_const(name, described_class)
 
     described_class.class_eval do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,4 +33,24 @@ Dir[Metasploit::Concern::Engine.root.join("spec/support/**/*.rb")].each { |f| re
 RSpec.configure do |config|
   config.mock_with :rspec
   config.order = :random
+
+  # rspec-rails 3 will no longer automatically infer an example group's spec type
+  # from the file location. You can explicitly opt-in to the feature using this
+  # config option.
+  # To explicitly tag specs without using automatic inference, set the `:type`
+  # metadata manually:
+  #
+  #     describe ThingsController, :type => :controller do
+  #       # Equivalent to being in spec/controllers
+  #     end
+  config.infer_spec_type_from_file_location!
+
+  # Setting this config option `false` removes rspec-core's monkey patching of the
+  # top level methods like `describe`, `shared_examples_for` and `shared_context`
+  # on `main` and `Module`. The methods are always available through the `RSpec`
+  # module like `RSpec.describe` regardless of this setting.
+  # For backwards compatibility this defaults to `true`.
+  #
+  # https://relishapp.com/rspec/rspec-core/v/3-0/docs/configuration/global-namespace-dsl
+  config.expose_dsl_globally = false
 end

--- a/spec/support/shared/examples/metasploit/concern/run.rb
+++ b/spec/support/shared/examples/metasploit/concern/run.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Metasploit::Concern.run' do
+RSpec.shared_examples_for 'Metasploit::Concern.run' do
   let(:load_hook_name) {
     described_class.name.underscore.gsub('/', '_').to_sym
   }


### PR DESCRIPTION
update all specs to latest Rspec 3 syntax

MS-1086

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [ ] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit/concern/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`