### PR TITLE
Staging/ms 888/engines is deprecated

### DIFF
--- a/lib/metasploit/concern/engine.rb
+++ b/lib/metasploit/concern/engine.rb
@@ -1,7 +1,11 @@
 require 'rails'
+# Refinement that returns engines method to Rails::Engine::Railties
+# so that we can access the engines deprecated in Rails 4.1
 module SupportEngines
+
   refine Rails::Engine::Railties do
     def engines
+      # method that returns all current engines
       @engines ||= ::Rails::Engine.subclasses.map(&:instance)
     end
   end
@@ -12,6 +16,7 @@ module Metasploit
     # Rails engine for Metasploit::Concern that sets up an initializer to load the concerns from app/concerns in other
     # Rails engines.
     using SupportEngines
+    # to apply the refinement
     class Engine < ::Rails::Engine
       #
       # `config`

--- a/lib/metasploit/concern/engine.rb
+++ b/lib/metasploit/concern/engine.rb
@@ -1,9 +1,17 @@
 require 'rails'
+module SupportEngines
+  refine Rails::Engine::Railties do
+    def engines
+      @engines ||= ::Rails::Engine.subclasses.map(&:instance)
+    end
+  end
+end
 
 module Metasploit
   module Concern
     # Rails engine for Metasploit::Concern that sets up an initializer to load the concerns from app/concerns in other
     # Rails engines.
+    using SupportEngines
     class Engine < ::Rails::Engine
       #
       # `config`

--- a/lib/metasploit/concern/engine.rb
+++ b/lib/metasploit/concern/engine.rb
@@ -1,17 +1,9 @@
 require 'rails'
-
+require File.expand_path("../support_engines", __FILE__)
 
 # Refinement that returns engines method to Rails::Engine::Railties
 # so that we can access the engines deprecated in Rails 4.1
-module SupportEngines
 
-  refine Rails::Engine::Railties do
-    def engines
-      # method that returns all current engines
-      @engines ||= ::Rails::Engine.subclasses.map(&:instance)
-    end
-  end
-end
 
 
 module Metasploit

--- a/lib/metasploit/concern/engine.rb
+++ b/lib/metasploit/concern/engine.rb
@@ -1,4 +1,6 @@
 require 'rails'
+
+
 # Refinement that returns engines method to Rails::Engine::Railties
 # so that we can access the engines deprecated in Rails 4.1
 module SupportEngines
@@ -10,6 +12,7 @@ module SupportEngines
     end
   end
 end
+
 
 module Metasploit
   module Concern

--- a/lib/metasploit/concern/support_engines.rb
+++ b/lib/metasploit/concern/support_engines.rb
@@ -1,0 +1,9 @@
+module SupportEngines
+
+  refine Rails::Engine::Railties do
+    def engines
+      # method that returns all current engines
+      @engines ||= ::Rails::Engine.subclasses.map(&:instance)
+    end
+  end
+end

--- a/lib/metasploit/concern/version.rb
+++ b/lib/metasploit/concern/version.rb
@@ -9,7 +9,7 @@ module Metasploit
       # The patch number, scoped to the {MINOR} version number.
       PATCH = 1
 
-      PRERELEASE = rails-4-upgrade
+      PRERELEASE = attr_reader engines-is-deprecated
 
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the

--- a/lib/metasploit/concern/version.rb
+++ b/lib/metasploit/concern/version.rb
@@ -9,7 +9,7 @@ module Metasploit
       # The patch number, scoped to the {MINOR} version number.
       PATCH = 1
 
-      PRERELEASE = engines-is-deprecated
+      PRERELEASE = 'engines-is-deprecated'
 
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the

--- a/lib/metasploit/concern/version.rb
+++ b/lib/metasploit/concern/version.rb
@@ -9,7 +9,7 @@ module Metasploit
       # The patch number, scoped to the {MINOR} version number.
       PATCH = 1
 
-      PRERELEASE = attr_reader engines-is-deprecated
+      PRERELEASE = engines-is-deprecated
 
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the

--- a/lib/metasploit/concern/version.rb
+++ b/lib/metasploit/concern/version.rb
@@ -8,7 +8,7 @@ module Metasploit
       MINOR = 0
       # The patch number, scoped to the {MINOR} version number.
       PATCH = 1
-
+      # Prerelease tag
       PRERELEASE = 'engines-is-deprecated'
 
 

--- a/spec/lib/metasploit/concern/support_engines_spec.rb
+++ b/spec/lib/metasploit/concern/support_engines_spec.rb
@@ -1,0 +1,27 @@
+class TestObject
+  using SupportEngines
+  def initialize
+
+  end
+
+  def get_engines
+    return Rails.application.railties.engines()
+  end
+end
+
+RSpec.describe SupportEngines do
+  context "when used" do
+    helper_object = TestObject.new()
+    engines = helper_object.get_engines
+    it "should not return nil" do
+      expect(engines).to_not be_nil
+    end
+
+    it "should return an array of valid engines" do
+      engines.each do |engine|
+        expect(engine).to be_a(Rails::Engine)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to staging/rails-upgrade or the build will be broke on staging/rails-upgrade.

## Version
- [ ] Edit `lib/metasploit/concern/version.rb`
- [ ] Change `PRERELEASE` from `engines-is-deprecated` to `rails-upgrade` to match the branch (staging/rails-upgrade) summary (rails-upgrade)

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the prerelease suffix has change on the gem.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin staging/rails-upgrade`