### PR TITLE
update deps where possible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,24 +20,18 @@ group :development, :test do
   # rails is not used because activerecord should not be included, but rails would normally coordinate the versions
   # between its dependencies, which is now handled by this constraint.
   # @todo MSP-9654
-  rails_version_constraint = [
-      '>= 4.1',
-      '< 4.2'
-  ]
   
   # Dummy app uses actionpack for ActionController, but not rails since it doesn't use activerecord.
-  gem 'actionpack', *rails_version_constraint
+  gem 'actionpack', '~> 4.1.15'
   # Engine tasks are loaded using railtie
-  gem 'railties', *rails_version_constraint
+  gem 'railties', '~> 4.1.15'
   # running documentation generation tasks and rspec tasks
   gem 'rake', '~> 10.5'
   # Used for Sql Lite Db
   gem 'sqlite3'
   # provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking.
   gem "minitest"
-  # need rspec-rails >= 2.12.0 as 2.12.0 adds support for redefining named subject in nested context that uses the
-  # named subject from the outer context without causing a stack overflow.
-  gem 'rspec-rails', '>= 2.12.0'
+  gem 'rspec-rails'
   # defines time zones for activesupport.  Must be explicit since it is normally implicit with activerecord
   gem 'tzinfo'
 end

--- a/metasploit-concern.gemspec
+++ b/metasploit-concern.gemspec
@@ -17,9 +17,7 @@ Gem::Specification.new do |s|
                   'descendents from other gems when layering schemas.'
 
   s.files = Dir['{app,config,lib}/**/*'] + ['CONTRIBUTING.md', 'LICENSE', 'Rakefile', 'README.md'] + Dir['spec/support/**/*.rb']
-  
-  rails_version_constraints = ['>= 4.1', '< 4.2']
-  
+
 
   s.required_ruby_version = '>= 2.1'
 
@@ -27,8 +25,8 @@ Gem::Specification.new do |s|
 
   # uses ActiveSupport.on_load to include concerns
   # it is only defined in version 3.0.0 and newer
-  s.add_runtime_dependency 'activemodel', *rails_version_constraints
-  s.add_runtime_dependency 'activesupport', *rails_version_constraints
+  s.add_runtime_dependency 'activemodel', '~> 4.1.15'
+  s.add_runtime_dependency 'activesupport', '~> 4.1.15'
   # for engine
-  s.add_runtime_dependency 'railties', *rails_version_constraints
+  s.add_runtime_dependency 'railties', '~> 4.1.15'
 end


### PR DESCRIPTION
updated the deps to latest rails 4.1 compat where
possible. shoulda-matchers has an issue which still
requires version lokcing here

MS-1330

VERIFICATION STEPS
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `rake spec`
- [x] VERIFY all specs pass