### PR TITLE
update to support rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ addons:
     packages:
       - graphviz
 rvm:
-  - 2.4.1
+  - 2.6.5
 before_install:
-  - gem update bundler
+  - gem install bundler
 script:
   - bundle exec rake spec
   - bundle exec rake cucumber

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :development, :test do
   # running documentation generation tasks and rspec tasks
   gem 'rake'
   # Used for Sql Lite Db
-  gem 'sqlite3', '~> 1.3.0'
+  gem 'sqlite3'
   # provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking.
   gem "minitest"
   gem 'rspec-rails'

--- a/lib/metasploit/concern/version.rb
+++ b/lib/metasploit/concern/version.rb
@@ -1,7 +1,7 @@
 module Metasploit
   module Concern
     # VERSION is managed by GemRelease
-    VERSION = '2.0.6'
+    VERSION = '3.0.0'
   
     # @return [String]
     #

--- a/metasploit-concern.gemspec
+++ b/metasploit-concern.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
 
   # uses ActiveSupport.on_load to include concerns
   # it is only defined in version 3.0.0 and newer
-  s.add_runtime_dependency 'activemodel', '~> 4.2.6'
-  s.add_runtime_dependency 'activesupport', '~> 4.2.6'
+  s.add_runtime_dependency 'activemodel', '~> 5.2.2'
+  s.add_runtime_dependency 'activesupport', '~> 5.2.2'
   # for engine
-  s.add_runtime_dependency 'railties', '~> 4.2.6'
+  s.add_runtime_dependency 'railties', '~> 5.2.2'
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -42,11 +42,8 @@ module Dummy
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 
-    # Enable the asset pipeline
-    config.assets.enabled = false
-
-    # Version of your assets, change this if you want to expire all your assets
-    config.assets.version = '1.0'
+    # Rails 5 requires this be set
+    config.active_record.sqlite3.represent_boolean_as_integer = true
 
     config.paths.add 'app/concerns', autoload: true
   end

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,8 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
-
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )


### PR DESCRIPTION
Depends on https://github.com/rapid7/metasploit-erd/pull/10

Updates dependencies to support Rails 5.2.

Due to compatibility options for Rails dependency this reflects a breaking change.

Set version to 3.0.0, open to input on version as 2.1.0 since no actual code changes.