### PR TITLE
Update support for 2.7 & maintainers info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ addons:
     packages:
       - graphviz
 rvm:
-  - 2.6.5
-before_install:
-  - gem install bundler
+  - 2.7.2
 script:
   - bundle exec rake spec
   - bundle exec rake cucumber

--- a/metasploit-concern.gemspec
+++ b/metasploit-concern.gemspec
@@ -7,8 +7,8 @@ require 'metasploit/concern/version'
 Gem::Specification.new do |s|
   s.name        = 'metasploit-concern'
   s.version     = Metasploit::Concern::VERSION
-  s.authors     = ['Luke Imhoff']
-  s.email       = ['luke_imhoff@rapid7.com']
+  s.authors     = ['Metasploit Hackers']
+  s.email       = ['msfdev@metasploit.com']
   s.homepage    = 'https://github.com/rapid7/metasploit-concern'
   s.license     = 'BSD-3-clause'
   s.summary     = 'Automatically include Modules from app/concerns'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,10 +14,10 @@ require 'simplecov'
 #   # don't generate local report as it is inaccessible on travis-ci, which is why coveralls is being used.
 #   SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 # else
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
       # either generate the local report
       SimpleCov::Formatter::HTMLFormatter
-  ]
+  ])
 # end
 
 require File.expand_path("../dummy/config/environment", __FILE__)


### PR DESCRIPTION
* Updates authors to reflect current maintainers
* Update travis to test with 2.7.2
* Update SimpleCov syntax

Warning removed is:
```
metasploit-concern/spec/spec_helper.rb:17:in `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.
```