### PR TITLE
Add ruby 3.1.1 to test matrix

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,10 +17,10 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - 2.5
           - 2.6
           - 2.7
           - 3.0
+          - 3.1
 
     env:
       RAILS_ENV: test


### PR DESCRIPTION
Relates to https://github.com/rapid7/metasploit-framework/pull/16373