### PR TITLE
Add support for rails 7

### DIFF
--- a/lib/metasploit/concern/engine.rb
+++ b/lib/metasploit/concern/engine.rb
@@ -41,12 +41,16 @@ module Metasploit
               raise Metasploit::Concern::Error::SkipAutoload, engine
             end
 
-            concerns_directories = concerns_path.existent_directories
+            ActiveSupport::Reloader.to_prepare do
+              # wrap engine configs changes in to_prepare to ensure they get recreated if classes are reloaded by zeitwerk
+              concerns_directories = concerns_path.existent_directories
 
-            concerns_directories.each do |concerns_directory|
-              concerns_pathname = Pathname.new(concerns_directory)
-              loader = Metasploit::Concern::Loader.new(root: concerns_pathname)
-              loader.register
+              concerns_directories.each do |concerns_directory|
+                concerns_pathname = Pathname.new(concerns_directory)
+
+                loader = Metasploit::Concern::Loader.new(root: concerns_pathname)
+                loader.register
+              end
             end
           end
         end

--- a/lib/metasploit/concern/loader.rb
+++ b/lib/metasploit/concern/loader.rb
@@ -87,7 +87,7 @@ class Metasploit::Concern::Loader
 
       ActiveSupport.on_load(on_load_name) do
         loader.each_pathname_constant(parent_pathname: module_pathname) do |concern|
-          include concern
+          include concern unless self.ancestors.map(&:name).include?(concern.to_s)
         end
       end
     end

--- a/lib/metasploit/concern/version.rb
+++ b/lib/metasploit/concern/version.rb
@@ -1,7 +1,7 @@
 module Metasploit
   module Concern
     # VERSION is managed by GemRelease
-    VERSION = '4.0.6'
+    VERSION = '5.0.0'
   
     # @return [String]
     #

--- a/metasploit-concern.gemspec
+++ b/metasploit-concern.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |s|
 
   # uses ActiveSupport.on_load to include concerns
   # it is only defined in version 3.0.0 and newer
-  s.add_runtime_dependency 'activemodel', '~> 6.0'
-  s.add_runtime_dependency 'activesupport', '~> 6.0'
+  s.add_runtime_dependency 'activemodel', '~> 7.0'
+  s.add_runtime_dependency 'activesupport', '~> 7.0'
   # for engine
-  s.add_runtime_dependency 'railties', '~> 6.0'
+  s.add_runtime_dependency 'railties', '~> 7.0'
   s.add_runtime_dependency 'zeitwerk'
 end

--- a/metasploit-concern.gemspec
+++ b/metasploit-concern.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,lib}/**/*'] + ['CONTRIBUTING.md', 'LICENSE', 'Rakefile', 'README.md'] + Dir['spec/support/**/*.rb']
 
 
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   s.add_development_dependency 'metasploit-yard'
   s.add_development_dependency 'metasploit-erd'

--- a/metasploit-concern.gemspec
+++ b/metasploit-concern.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport', '~> 6.0'
   # for engine
   s.add_runtime_dependency 'railties', '~> 6.0'
+  s.add_runtime_dependency 'zeitwerk'
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -44,7 +44,19 @@ module Dummy
 
     config.paths.add 'app/concerns', autoload: true
 
-    config.autolaoder = :zeitwerk
+    config.autoloader = :zeitwerk
+
+    initializer :metaspliot_concern_test_reloading, before: :setup_main_autoloader do
+      Rails.autoloaders.each do |loader|
+        loader.enable_reloading
+      end
+    end
+
+    initializer :metaspliot_concern_test_reloading, before: :setup_once_autoloader do
+      Rails.autoloaders.each do |loader|
+        loader.enable_reloading
+      end
+    end
   end
 end
 

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -57,6 +57,8 @@ module Dummy
         loader.enable_reloading
       end
     end
+    
+    ActiveRecord.legacy_connection_handling = false
   end
 end
 

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -46,13 +46,13 @@ module Dummy
 
     config.autoloader = :zeitwerk
 
-    initializer :metaspliot_concern_test_reloading, before: :setup_main_autoloader do
+    initializer :metasploit_concern_test_reloading, before: :setup_main_autoloader do
       Rails.autoloaders.each do |loader|
         loader.enable_reloading
       end
     end
 
-    initializer :metaspliot_concern_test_reloading, before: :setup_once_autoloader do
+    initializer :metasploit_concern_test_reloading, before: :setup_once_autoloader do
       Rails.autoloaders.each do |loader|
         loader.enable_reloading
       end

--- a/spec/lib/metasploit/concern/engine_spec.rb
+++ b/spec/lib/metasploit/concern/engine_spec.rb
@@ -104,15 +104,8 @@ RSpec.describe Metasploit::Concern::Engine do
                 }.not_to raise_error
               end
 
-              it "creates Metasploit::Concern::Loader for engine's app/concerns" do
-                expect(Metasploit::Concern::Loader).to receive(:new).with(
-                                                           hash_including(
-                                                               root: root.join('app', 'concerns')
-                                                           )
-                                                       ).and_return(
-                                                           double(register: nil)
-                                                       )
-
+              it "registers concern load via ActiveSupport::Reloader.to_prepare for for engine's app/concerns" do
+                expect(ActiveSupport::Reloader).to receive(:to_prepare)
                 load_concerns.run
               end
             end


### PR DESCRIPTION
* Update `metasploit-concern` to remove calls to APIs being removed in Rails 7.
* add `zeitwerk` as a direct dependency as this is the mode tested in specs

The features are still tied to Rails and usable only in `Rails::Application` or `Rails::Engine` scopes.

Since many of the specs also relied on APIs being removed in Rails changes evaluate different aspects of the runtime environment. Inspection is deferred to `Zeitwerk` as the arbiter of `autoload` namespaces in `Rails`.

Relies on https://github.com/rapid7/metasploit-erd/pull/18