### PR TITLE
Remove hardcoded secret

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development, :test do
   # rails is not used because activerecord should not be included, but rails would normally coordinate the versions
   # between its dependencies, which is now handled by this constraint.
   # @todo MSP-9654
-  
+
   # Dummy app uses actionpack for ActionController, but not rails since it doesn't use activerecord.
   gem 'actionpack'
   # Engine tasks are loaded using railtie
@@ -24,7 +24,7 @@ group :development, :test do
   # running documentation generation tasks and rspec tasks
   gem 'rake'
   # Used for Sql Lite Db
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.7'
   # provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking.
   gem "minitest"
   gem 'rspec-rails'

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -57,8 +57,5 @@ module Dummy
         loader.enable_reloading
       end
     end
-    
-    ActiveRecord.legacy_connection_handling = false
   end
 end
-

--- a/spec/dummy/config/initializers/secret_token.rb
+++ b/spec/dummy/config/initializers/secret_token.rb
@@ -1,7 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-Dummy::Application.config.secret_token = 'aa65efdc74ffe579a42d95ab0d9f6a47305420e30e92f6ea1791491909b6397801261700300b15a1dae477328a2ebf7fe426afb43aa58544bf616ee42a6cb255'


### PR DESCRIPTION
Resolves a snyk issue with a hardcoded secret, not a valid security concern since it's in the test suite but it can be removed anyway, I was able to remove the whole file since `secret_token` hasn't been in use since migrating to rails 4 

https://guides.rubyonrails.org/v4.0.8/upgrading_ruby_on_rails.html#:~:text=%23%20end-,2.6%20Action%20Pack,-Rails%204.0%20introduces

Also needed to pin the sqlite3 version as we have done in framework https://github.com/rapid7/metasploit-framework/blob/24fa34e7b994f8bb18a47e90eec763d310a9116a/metasploit-framework.gemspec#L201-L202

and removed a deprecated activerecord config option